### PR TITLE
Rebrand the module from thycotic to delinea

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # The Delinea Secret Server SDK for Go
 
-![Tests](https://github.com/thycotic/tss-sdk-go/workflows/Tests/badge.svg)
+![Tests](https://github.com/DelineaXPM/tss-sdk-go/workflows/Tests/badge.svg)
 
 A Golang API and examples for [Delinea](https://delinea.com/)
 [Secret Server](https://delinea.com/products/secret-server/).

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
-module github.com/thycotic/tss-sdk-go
+module github.com/DelineaXPM/tss-sdk-go
 
 go 1.13

--- a/main.go
+++ b/main.go
@@ -5,7 +5,7 @@ import (
 	"log"
 	"os"
 
-	"github.com/thycotic/tss-sdk-go/server"
+	"github.com/DelineaXPM/tss-sdk-go/server"
 )
 
 func main() {


### PR DESCRIPTION
- Renamed the module to delinea
- Updated the readme badges to reflect the new GitHub location