### PR TITLE
Fix(api) added configuration.apiVersion to all secret server API calls

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,3 +28,5 @@
 .vscode
 .idea
 test_config.json
+
+.DS_Store

--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,4 @@
 test_config.json
 
 .DS_Store
+bh_test.go

--- a/go.mod
+++ b/go.mod
@@ -1,5 +1,10 @@
 module github.com/DelineaXPM/tss-sdk-go/v2
 
-go 1.13
+go 1.22
 
-require github.com/tidwall/gjson v1.17.1 // indirect
+require github.com/tidwall/gjson v1.17.1
+
+require (
+	github.com/tidwall/match v1.1.1 // indirect
+	github.com/tidwall/pretty v1.2.0 // indirect
+)

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,5 @@
 module github.com/DelineaXPM/tss-sdk-go/v2
 
 go 1.13
+
+require github.com/tidwall/gjson v1.17.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,6 @@
+github.com/tidwall/gjson v1.17.1 h1:wlYEnwqAHgzmhNUFfw7Xalt2JzQvsMx2Se4PcoFCT/U=
+github.com/tidwall/gjson v1.17.1/go.mod h1:/wbyibRr2FHMks5tjHJ5F8dMZh3AcwJEMf5vlfC0lxk=
+github.com/tidwall/match v1.1.1 h1:+Ho715JplO36QYgwN9PGYNhgZvoUSc9X2c80KVTi+GA=
+github.com/tidwall/match v1.1.1/go.mod h1:eRSPERbgtNPcGhD8UCthc6PmLEQXEWd3PRB5JTxsfmM=
+github.com/tidwall/pretty v1.2.0 h1:RWIZEg2iJ8/g6fDDYzMpobmaoGh5OLl4AXtGUGPcqCs=
+github.com/tidwall/pretty v1.2.0/go.mod h1:ITEVvHYasfjBbM0u2Pg8T2nJnzm8xPwvNhhsoaGGjNU=

--- a/main.go
+++ b/main.go
@@ -2,122 +2,32 @@ package main
 
 import (
 	"fmt"
-	"encoding/json"
 	"log"
 	"os"
 
 	"github.com/DelineaXPM/tss-sdk-go/v2/server"
-	
-	_"github.com/tidwall/gjson"
 )
-/*
-TSS_USERNAME
-TSS_PASSWORD
-TSS_TENANT
-TSS_SERVER_URL
-TSS_TLD
-*/
 
 func main() {
-	os.Setenv("TSS_USERNAME", "dsvtest")
-	os.Setenv("TSS_PASSWORD", "testTEST1234!")
-	os.Setenv("TSS_SERVER_URL", "https://rasteamdev.qa.devsecretservercloud.com")
-
-
-
 	tss, err := server.New(server.Configuration{
 		Credentials: server.UserCredential{
 			Username: os.Getenv("TSS_USERNAME"),
 			Password: os.Getenv("TSS_PASSWORD"),
 		},
-/* 		Tenant: os.Getenv("TSS_TENANT"), */
-	    ServerURL: os.Getenv("TSS_SERVER_URL"),
-	    TLD: "com",
+		Tenant: os.Getenv("TSS_TENANT"),
 	})
 
 	if err != nil {
 		log.Fatal("Error initializing the server configuration", err)
 	}
 
-// Get secret by ID
-/*	s, err := tss.Secret(49490) // Unix Account (SSH) 					   password = Items.2.ItemValue  */
-/*	s, err := tss.Secret(49268) // Unix Account (SSH) 					   password = Items.2.ItemValue */
-/*	s, err := tss.Secret(51462) // DevOps Secrets Vault Client Credentials password = Items.2.ItemValue */
-/*	s, err := tss.Secret(51463) // MySql Account 						   password = Items.2.ItemValue */
-/*	s, err := tss.Secret(51468) // Oracle Account						   password = Items.4.ItemValue */
-/*	s, err := tss.Secret(51470) // SQL Server Account					   password = Items.2.ItemValue*/
-/*	s, err := tss.Secret(51474) // SAP Account					   		   password = Items.2.ItemValue*/
-/*	s, err := tss.Secret(51475) // Windows Account					   	   password = Items.2.ItemValue*/
-/*	s, err := tss.Secret(53389) // Unix Account (SSH) 					   password = Items.2.ItemValue  */
-	
-/*	s, err := tss.Secret(53974) // External-Secret (SSH) 				   data = Items.0.ItemValue  	*/
+	s, err := tss.Secret(1)
 
-// Get secret by searchText and field
-	s, err := tss.Secrets("ESO-test-secret", "name")
-	
-// Create new secret
-/*
-	secretModel := new(server.Secret)
-	secretModel.Name = "Bill Test secret delete me"
-	secretModel.SiteID = 1
-	secretModel.FolderID = 67
-	secretModel.SecretTemplateID = 6007
-	secretModel.AutoChangeEnabled = false
-	secretModel.Fields = make([]server.SecretField, 3)
-	secretModel.Fields[0].FieldID = 108 // machine
-	secretModel.Fields[0].ItemValue = "DSV TEST MACHINE"
-	secretModel.Fields[1].FieldID = 111 // username
-	secretModel.Fields[1].ItemValue = "dsv_username"
-	secretModel.Fields[2].FieldID = 110 // password
-	secretModel.Fields[2].ItemValue = "dsv_password"
-
-	s, err := tss.CreateSecret(*secretModel)
-*/
-
-// Update a secret
-/*
-	secretModel := new(server.Secret)
-	secretModel.ID = 49490
-	secretModel.Name = "DSV update test secret"
-	secretModel.Fields = make([]server.SecretField, 1)
-	secretModel.Fields[0].FieldID = 110 // password
-	secretModel.Fields[0].ItemValue = "someNewPassword"
-	s, err := tss.UpdateSecret(*secretModel)
-*/
-
-
-// Delete Secret
-/*
-	s := ""
-	err = tss.DeleteSecret(53392)
-*/
-
-/*
-	fmt.Printf("\n\n%+v \n\n", s)
 	if err != nil {
-		log.Fatal("[Error]: ", err)
+		log.Fatal("Error calling server.Secret", err)
 	}
-*/
-	
-	jsonStr, err := json.Marshal(s)
-	if err != nil {
-		fmt.Println(err)
-		return
-	}
-	// extract key from secret using gjson
-/*
-	val := gjson.Get(string(jsonStr), "Items.0.ItemValue")
-	if !val.Exists() {
-		fmt.Printf("property = %s ... %s ", val)
-		return  
-	}
-*/
 
-	fmt.Println(string(jsonStr))
-	
-/*
 	if pw, ok := s.Field("password"); ok {
-		fmt.Print("\n\nthe password is ", pw, "\n\n")
+		fmt.Print("the password is", pw)
 	}
-*/
 }

--- a/main.go
+++ b/main.go
@@ -2,32 +2,122 @@ package main
 
 import (
 	"fmt"
+	"encoding/json"
 	"log"
 	"os"
 
 	"github.com/DelineaXPM/tss-sdk-go/v2/server"
+	
+	_"github.com/tidwall/gjson"
 )
+/*
+TSS_USERNAME
+TSS_PASSWORD
+TSS_TENANT
+TSS_SERVER_URL
+TSS_TLD
+*/
 
 func main() {
+	os.Setenv("TSS_USERNAME", "dsvtest")
+	os.Setenv("TSS_PASSWORD", "testTEST1234!")
+	os.Setenv("TSS_SERVER_URL", "https://rasteamdev.qa.devsecretservercloud.com")
+
+
+
 	tss, err := server.New(server.Configuration{
 		Credentials: server.UserCredential{
 			Username: os.Getenv("TSS_USERNAME"),
 			Password: os.Getenv("TSS_PASSWORD"),
 		},
-		Tenant: os.Getenv("TSS_TENANT"),
+/* 		Tenant: os.Getenv("TSS_TENANT"), */
+	    ServerURL: os.Getenv("TSS_SERVER_URL"),
+	    TLD: "com",
 	})
 
 	if err != nil {
 		log.Fatal("Error initializing the server configuration", err)
 	}
 
-	s, err := tss.Secret(1)
+// Get secret by ID
+/*	s, err := tss.Secret(49490) // Unix Account (SSH) 					   password = Items.2.ItemValue  */
+/*	s, err := tss.Secret(49268) // Unix Account (SSH) 					   password = Items.2.ItemValue */
+/*	s, err := tss.Secret(51462) // DevOps Secrets Vault Client Credentials password = Items.2.ItemValue */
+/*	s, err := tss.Secret(51463) // MySql Account 						   password = Items.2.ItemValue */
+/*	s, err := tss.Secret(51468) // Oracle Account						   password = Items.4.ItemValue */
+/*	s, err := tss.Secret(51470) // SQL Server Account					   password = Items.2.ItemValue*/
+/*	s, err := tss.Secret(51474) // SAP Account					   		   password = Items.2.ItemValue*/
+/*	s, err := tss.Secret(51475) // Windows Account					   	   password = Items.2.ItemValue*/
+/*	s, err := tss.Secret(53389) // Unix Account (SSH) 					   password = Items.2.ItemValue  */
+	
+/*	s, err := tss.Secret(53974) // External-Secret (SSH) 				   data = Items.0.ItemValue  	*/
 
+// Get secret by searchText and field
+	s, err := tss.Secrets("ESO-test-secret", "name")
+	
+// Create new secret
+/*
+	secretModel := new(server.Secret)
+	secretModel.Name = "Bill Test secret delete me"
+	secretModel.SiteID = 1
+	secretModel.FolderID = 67
+	secretModel.SecretTemplateID = 6007
+	secretModel.AutoChangeEnabled = false
+	secretModel.Fields = make([]server.SecretField, 3)
+	secretModel.Fields[0].FieldID = 108 // machine
+	secretModel.Fields[0].ItemValue = "DSV TEST MACHINE"
+	secretModel.Fields[1].FieldID = 111 // username
+	secretModel.Fields[1].ItemValue = "dsv_username"
+	secretModel.Fields[2].FieldID = 110 // password
+	secretModel.Fields[2].ItemValue = "dsv_password"
+
+	s, err := tss.CreateSecret(*secretModel)
+*/
+
+// Update a secret
+/*
+	secretModel := new(server.Secret)
+	secretModel.ID = 49490
+	secretModel.Name = "DSV update test secret"
+	secretModel.Fields = make([]server.SecretField, 1)
+	secretModel.Fields[0].FieldID = 110 // password
+	secretModel.Fields[0].ItemValue = "someNewPassword"
+	s, err := tss.UpdateSecret(*secretModel)
+*/
+
+
+// Delete Secret
+/*
+	s := ""
+	err = tss.DeleteSecret(53392)
+*/
+
+/*
+	fmt.Printf("\n\n%+v \n\n", s)
 	if err != nil {
-		log.Fatal("Error calling server.Secret", err)
+		log.Fatal("[Error]: ", err)
 	}
+*/
+	
+	jsonStr, err := json.Marshal(s)
+	if err != nil {
+		fmt.Println(err)
+		return
+	}
+	// extract key from secret using gjson
+/*
+	val := gjson.Get(string(jsonStr), "Items.0.ItemValue")
+	if !val.Exists() {
+		fmt.Printf("property = %s ... %s ", val)
+		return  
+	}
+*/
 
+	fmt.Println(string(jsonStr))
+	
+/*
 	if pw, ok := s.Field("password"); ok {
-		fmt.Print("the password is", pw)
+		fmt.Print("\n\nthe password is ", pw, "\n\n")
 	}
+*/
 }

--- a/server/http.go
+++ b/server/http.go
@@ -2,7 +2,7 @@ package server
 
 import (
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 )
 
@@ -14,7 +14,7 @@ func handleResponse(res *http.Response, err error) ([]byte, *http.Response, erro
 		return nil, res, err
 	}
 
-	data, err := ioutil.ReadAll(res.Body)
+	data, err := io.ReadAll(res.Body)
 
 	if err != nil {
 		return nil, res, err

--- a/server/secret_template.go
+++ b/server/secret_template.go
@@ -28,7 +28,7 @@ type SecretTemplateField struct {
 func (s Server) SecretTemplate(id int) (*SecretTemplate, error) {
 	secretTemplate := new(SecretTemplate)
 
-	if data, err := s.accessResource("GET", templateResource, strconv.Itoa(id), nil); err == nil {
+	if data, err := s.accessResource("GET", templateResource, strconv.Itoa(id), "v1/", nil); err == nil {
 		if err = json.Unmarshal(data, secretTemplate); err != nil {
 			log.Printf("[ERROR] error parsing response from /%s/%d: %q", templateResource, id, data)
 			return nil, err
@@ -52,7 +52,7 @@ func (s Server) GeneratePassword(slug string, template *SecretTemplate) (string,
 	}
 	path := fmt.Sprintf("generate-password/%d", fieldId)
 
-	if data, err := s.accessResource("POST", templateResource, path, nil); err == nil {
+	if data, err := s.accessResource("POST", templateResource, path, "v1/", nil); err == nil {
 		passwordWithQuotes := string(data)
 		return passwordWithQuotes[1 : len(passwordWithQuotes)-1], nil
 	} else {

--- a/server/secret_template_test.go
+++ b/server/secret_template_test.go
@@ -25,7 +25,7 @@ func TestSecretTemplate(t *testing.T) {
 		return
 	}
 
-	if template == nil {
+	if template == nil || template.Fields == nil {
 		t.Error("secret data is nil")
 	}
 


### PR DESCRIPTION
Added configuration.apiVersion to all secret server API calls.
Fixed code so all linters run successfully
Fixed unit tests to work with newest versions of SS api calls and to run successfully.

## Pull request checklist

Please check if your PR fulfills the following requirements:

- [ √] You have read the contributing guide
- [ √] Tests for the changes have been added
- [ √] The documentation has been reviewed and updated as needed

## What is the current behavior?

Currently all API calls to secret server are using api/v1 ... some of these API's have been updated to api/v2.

## What is the new behavior?
- All calls to functions accessResource() & searchResources() now include a new parameter to determine the version of the requested API to  call.

## Does this introduce a breaking change?

- [ ] Yes
- [√ ] No

**If yes, please describe...**

## Other relevant information

