### PR TITLE
feat: Added a simple caching feature for access tokens

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,3 +28,5 @@
 .vscode
 .idea
 test_config.json
+.DS_Store
+main.go~

--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,4 @@ module github.com/DelineaXPM/tss-sdk-go/v2
 
 go 1.13
 
-require (
-	github.com/patrickmn/go-cache v2.1.0+incompatible // indirect
-	github.com/tidwall/gjson v1.18.0 // indirect
-)
+require github.com/tidwall/gjson v1.18.0

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,8 @@
 module github.com/DelineaXPM/tss-sdk-go/v2
 
 go 1.13
+
+require (
+	github.com/patrickmn/go-cache v2.1.0+incompatible // indirect
+	github.com/tidwall/gjson v1.18.0 // indirect
+)

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,8 @@
+github.com/patrickmn/go-cache v2.1.0+incompatible h1:HRMgzkcYKYpi3C8ajMPV8OFXaaRUnok+kx1WdO15EQc=
+github.com/patrickmn/go-cache v2.1.0+incompatible/go.mod h1:3Qf8kWWT7OJRJbdiICTKqZju1ZixQ/KpMGzzAfe6+WQ=
+github.com/tidwall/gjson v1.18.0 h1:FIDeeyB800efLX89e5a8Y0BNH+LOngJyGrIWxG2FKQY=
+github.com/tidwall/gjson v1.18.0/go.mod h1:/wbyibRr2FHMks5tjHJ5F8dMZh3AcwJEMf5vlfC0lxk=
+github.com/tidwall/match v1.1.1 h1:+Ho715JplO36QYgwN9PGYNhgZvoUSc9X2c80KVTi+GA=
+github.com/tidwall/match v1.1.1/go.mod h1:eRSPERbgtNPcGhD8UCthc6PmLEQXEWd3PRB5JTxsfmM=
+github.com/tidwall/pretty v1.2.0 h1:RWIZEg2iJ8/g6fDDYzMpobmaoGh5OLl4AXtGUGPcqCs=
+github.com/tidwall/pretty v1.2.0/go.mod h1:ITEVvHYasfjBbM0u2Pg8T2nJnzm8xPwvNhhsoaGGjNU=

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,3 @@
-github.com/patrickmn/go-cache v2.1.0+incompatible h1:HRMgzkcYKYpi3C8ajMPV8OFXaaRUnok+kx1WdO15EQc=
-github.com/patrickmn/go-cache v2.1.0+incompatible/go.mod h1:3Qf8kWWT7OJRJbdiICTKqZju1ZixQ/KpMGzzAfe6+WQ=
 github.com/tidwall/gjson v1.18.0 h1:FIDeeyB800efLX89e5a8Y0BNH+LOngJyGrIWxG2FKQY=
 github.com/tidwall/gjson v1.18.0/go.mod h1:/wbyibRr2FHMks5tjHJ5F8dMZh3AcwJEMf5vlfC0lxk=
 github.com/tidwall/match v1.1.1 h1:+Ho715JplO36QYgwN9PGYNhgZvoUSc9X2c80KVTi+GA=

--- a/server/server.go
+++ b/server/server.go
@@ -8,11 +8,14 @@ import (
 	"io"
 	"io/ioutil"
 	"log"
+	"math"
 	"mime/multipart"
 	"net/http"
 	"net/url"
+	"os"
 	"regexp"
 	"strings"
+	"time"
 )
 
 const (
@@ -20,6 +23,7 @@ const (
 	defaultAPIPathURI    string = "/api/v1"
 	defaultTokenPathURI  string = "/oauth2/token"
 	defaultTLD           string = "com"
+	cacheTokenName       string = "access_token"
 )
 
 // UserCredential holds the username and password that the API should use to
@@ -38,6 +42,11 @@ type Configuration struct {
 // Server provides access to secrets stored in Delinea Secret Server
 type Server struct {
 	Configuration
+}
+
+type TokenCache struct {
+	AccessToken string `json:"access_token"`
+	ExpiresIn   int    `json:"expires_in"`
 }
 
 // New returns an initialized Secrets object
@@ -252,12 +261,44 @@ func (s Server) uploadFile(secretId int, fileField SecretField) error {
 	return err
 }
 
+func (s *Server) setCacheAccessToken(key, value string, expiresIn int) error {
+
+	cache := TokenCache{}
+	cache.AccessToken = value
+	cache.ExpiresIn = (int(time.Now().Unix()) + expiresIn) - int(math.Floor(float64(expiresIn)*0.9))
+
+	data, _ := json.Marshal(cache)
+	os.Setenv("SS_AT", string(data))
+	return nil
+}
+
+func (s *Server) getCacheAccessToken(key string) (string, bool) {
+	data, ok := os.LookupEnv("SS_AT")
+	if !ok {
+		os.Setenv("SS_AT", "")
+		return "", ok
+	}
+	cache := TokenCache{}
+	if err := json.Unmarshal([]byte(data), &cache); err != nil {
+		return "", false
+	}
+	if time.Now().Unix() < int64(cache.ExpiresIn) {
+		return cache.AccessToken, true
+	}
+	return "", false
+}
+
 // getAccessToken gets an OAuth2 Access Grant and returns the token
 // endpoint and get an accessGrant.
 func (s *Server) getAccessToken() (string, error) {
 	if s.Credentials.Token != "" {
 		return s.Credentials.Token, nil
 	}
+	accessToken, found := s.getCacheAccessToken(cacheTokenName)
+	if found {
+		return accessToken, nil
+	}
+
 	response, err := s.checkPlatformDetails()
 	if err != nil {
 		log.Print("Error while checking server details:", err)
@@ -292,6 +333,7 @@ func (s *Server) getAccessToken() (string, error) {
 			log.Print("[ERROR] parsing grant response:", err)
 			return "", err
 		}
+		s.setCacheAccessToken(cacheTokenName, grant.AccessToken, grant.ExpiresIn)
 		return grant.AccessToken, nil
 	} else {
 		return response, nil

--- a/server/server.go
+++ b/server/server.go
@@ -261,7 +261,6 @@ func (s Server) uploadFile(secretId int, fileField SecretField) error {
 }
 
 func (s *Server) setCacheAccessToken(value string, expiresIn int) error {
-
 	cache := TokenCache{}
 	cache.AccessToken = value
 	cache.ExpiresIn = (int(time.Now().Unix()) + expiresIn) - int(math.Floor(float64(expiresIn)*0.9))

--- a/server/server.go
+++ b/server/server.go
@@ -23,7 +23,6 @@ const (
 	defaultAPIPathURI    string = "/api/v1"
 	defaultTokenPathURI  string = "/oauth2/token"
 	defaultTLD           string = "com"
-	cacheTokenName       string = "access_token"
 )
 
 // UserCredential holds the username and password that the API should use to
@@ -261,7 +260,7 @@ func (s Server) uploadFile(secretId int, fileField SecretField) error {
 	return err
 }
 
-func (s *Server) setCacheAccessToken(key, value string, expiresIn int) error {
+func (s *Server) setCacheAccessToken(value string, expiresIn int) error {
 
 	cache := TokenCache{}
 	cache.AccessToken = value
@@ -272,7 +271,7 @@ func (s *Server) setCacheAccessToken(key, value string, expiresIn int) error {
 	return nil
 }
 
-func (s *Server) getCacheAccessToken(key string) (string, bool) {
+func (s *Server) getCacheAccessToken() (string, bool) {
 	data, ok := os.LookupEnv("SS_AT")
 	if !ok {
 		os.Setenv("SS_AT", "")
@@ -294,7 +293,7 @@ func (s *Server) getAccessToken() (string, error) {
 	if s.Credentials.Token != "" {
 		return s.Credentials.Token, nil
 	}
-	accessToken, found := s.getCacheAccessToken(cacheTokenName)
+	accessToken, found := s.getCacheAccessToken()
 	if found {
 		return accessToken, nil
 	}
@@ -333,7 +332,7 @@ func (s *Server) getAccessToken() (string, error) {
 			log.Print("[ERROR] parsing grant response:", err)
 			return "", err
 		}
-		s.setCacheAccessToken(cacheTokenName, grant.AccessToken, grant.ExpiresIn)
+		s.setCacheAccessToken(grant.AccessToken, grant.ExpiresIn)
 		return grant.AccessToken, nil
 	} else {
 		return response, nil


### PR DESCRIPTION
---
name: Access token caching feature
about: Added a simple caching feature for access tokens
---

## Pull request checklist

Please check if your PR fulfills the following requirements:

- [√ ] You have read the contributing guide
- [ √] Tests for the changes have been added
- [√ ] The documentation has been reviewed and updated as needed

## What is the current behavior?

_Please describe the current behavior that you are modifying, and link its a relevant issue_
Request for access token to made prior to every request for a secret

Issue Number: _Add the issue number this PR address here._
https://thycotic.visualstudio.com/Delinea.Work/_workitems/edit/608727

## What is the new behavior?
Access token is cached as an ENV variable. Expiration is based on ExpiresIn attribute received with the access token i.e.
ExpiresIn * .9 = cache expiration time
-
-
-

## Does this introduce a breaking change?

- [ ] Yes
- [ √] No

**If yes, please describe...**

## Other relevant information

_e.g. does this PR require another PR to be merged first?_
No
