### PR TITLE
feat: Added simple access token caching

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,3 +28,4 @@
 .vscode
 .idea
 test_config.json
+.DS_Store


### PR DESCRIPTION
---
name: Access Token Caching
---

## Pull request checklist

Please check if your PR fulfills the following requirements:

- [ √] You have read the contributing guide
- [ √] Tests for the changes have been added
- [ √] The documentation has been reviewed and updated as needed

## What is the current behavior?
_Please describe the current behavior that you are modifying, and link its a relevant issue_
API call for access token occurs prior to token expiration.

Issue Number: _Add the issue number this PR address here._
https://thycotic.visualstudio.com/Delinea.Work/_workitems/edit/608727

## What is the new behavior?
Access token is cached for token TTL * .9
-
-
-

## Does this introduce a breaking change?

- [ ] Yes
- [√ ] No

**If yes, please describe...**

## Other relevant information

_e.g. does this PR require another PR to be merged first?_
