### PR TITLE
Added simple access token caching

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,3 +28,4 @@
 .vscode
 .idea
 test_config.json
+.DS_Store


### PR DESCRIPTION
Cached token in environment variable for reuse
- When storing the key in the environment variable, the key is created by concatenating the server URL with the string 'SS_AT_'. This makes it easier to differentiate tokens for different servers.