### PR TITLE
feat: Add context support to all public API methods

### DIFF
--- a/server/secret.go
+++ b/server/secret.go
@@ -1,6 +1,7 @@
 package server
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"net/url"
@@ -46,11 +47,18 @@ type SshKeyArgs struct {
 	GeneratePassphrase, GenerateSshKeys bool
 }
 
-// Secret gets the secret with id from the Secret Server of the given tenant
+// Secret gets the secret with id from the Secret Server of the given tenant.
+// It uses context.Background() internally; use SecretWithContext to supply a context.
 func (s Server) Secret(id int) (*Secret, error) {
+	return s.SecretWithContext(context.Background(), id)
+}
+
+// SecretWithContext gets the secret with id from the Secret Server of the given tenant.
+// The provided context controls cancellation and deadlines for all HTTP requests made.
+func (s Server) SecretWithContext(ctx context.Context, id int) (*Secret, error) {
 	secret := new(Secret)
 
-	if data, err := s.accessResource("GET", resource, strconv.Itoa(id), nil); err == nil {
+	if data, err := s.accessResource(ctx, "GET", resource, strconv.Itoa(id), nil); err == nil {
 		if err = json.Unmarshal(data, secret); err != nil {
 			s.log().Printf("[ERROR] error parsing response from /%s/%d: %q", resource, id, data)
 			return nil, err
@@ -65,7 +73,7 @@ func (s Server) Secret(id int) (*Secret, error) {
 		if element.IsFile && element.FileAttachmentID != 0 && element.Filename != "" {
 			path := fmt.Sprintf("%d/fields/%s", id, element.Slug)
 
-			if data, err := s.accessResource("GET", resource, path, nil); err == nil {
+			if data, err := s.accessResource(ctx, "GET", resource, path, nil); err == nil {
 				secret.Fields[index].ItemValue = string(data)
 			} else {
 				return nil, err
@@ -76,10 +84,17 @@ func (s Server) Secret(id int) (*Secret, error) {
 	return secret, nil
 }
 
-// Secret gets the secret with id from the Secret Server of the given tenant
+// Secrets searches for secrets matching searchText and returns them fully populated.
+// It uses context.Background() internally; use SecretsWithContext to supply a context.
 func (s Server) Secrets(searchText, field string) ([]Secret, error) {
+	return s.SecretsWithContext(context.Background(), searchText, field)
+}
+
+// SecretsWithContext searches for secrets matching searchText and returns them fully populated.
+// The provided context controls cancellation and deadlines for all HTTP requests made.
+func (s Server) SecretsWithContext(ctx context.Context, searchText, field string) ([]Secret, error) {
 	searchResult := new(SearchResult)
-	if data, err := s.searchResources(resource, searchText, field); err == nil {
+	if data, err := s.searchResources(ctx, resource, searchText, field); err == nil {
 		if err = json.Unmarshal(data, searchResult); err != nil {
 			s.log().Printf("[ERROR] error parsing response from /%s/%s: %q", resource, searchText, data)
 			return nil, err
@@ -92,7 +107,7 @@ func (s Server) Secrets(searchText, field string) ([]Secret, error) {
 	secrets := make([]Secret, len(searchRecords))
 	for i, record := range searchRecords {
 		//secrets returned in search results are not fully populated
-		secret, err := s.Secret(record.ID)
+		secret, err := s.SecretWithContext(ctx, record.ID)
 		if err != nil {
 			return nil, err
 		}
@@ -102,14 +117,22 @@ func (s Server) Secrets(searchText, field string) ([]Secret, error) {
 	return secrets, nil
 }
 
+// SecretByPath gets the secret at the given path from the Secret Server of the given tenant.
+// It uses context.Background() internally; use SecretByPathWithContext to supply a context.
 func (s Server) SecretByPath(secretPath string) (*Secret, error) {
+	return s.SecretByPathWithContext(context.Background(), secretPath)
+}
+
+// SecretByPathWithContext gets the secret at the given path from the Secret Server of the given tenant.
+// The provided context controls cancellation and deadlines for all HTTP requests made.
+func (s Server) SecretByPathWithContext(ctx context.Context, secretPath string) (*Secret, error) {
 	secret := new(Secret)
 	// Encode the secret path to be safe for URLs
 	encodedPath := url.QueryEscape(secretPath)
 	queryPath := fmt.Sprintf("0?secretPath=%s", encodedPath)
 
 	// Perform the GET request to the 'secrets' resource with the specified path
-	if data, err := s.accessResource("GET", resource, queryPath, nil); err == nil {
+	if data, err := s.accessResource(ctx, "GET", resource, queryPath, nil); err == nil {
 		if err = json.Unmarshal(data, secret); err != nil {
 			s.log().Printf("[ERROR] error parsing response from /%s/%s: %q", resource, secretPath, data)
 			return nil, err
@@ -124,7 +147,7 @@ func (s Server) SecretByPath(secretPath string) (*Secret, error) {
 		if element.IsFile && element.FileAttachmentID != 0 && element.Filename != "" {
 			path := fmt.Sprintf("%d/fields/%s", secret.ID, element.Slug)
 
-			if data, err := s.accessResource("GET", resource, path, nil); err == nil {
+			if data, err := s.accessResource(ctx, "GET", resource, path, nil); err == nil {
 				secret.Fields[index].ItemValue = string(data)
 			} else {
 				return nil, err
@@ -135,24 +158,40 @@ func (s Server) SecretByPath(secretPath string) (*Secret, error) {
 	return secret, nil
 }
 
+// CreateSecret creates a new secret and returns it.
+// It uses context.Background() internally; use CreateSecretWithContext to supply a context.
 func (s Server) CreateSecret(secret Secret) (*Secret, error) {
-	return s.writeSecret(secret, "POST", "/")
+	return s.CreateSecretWithContext(context.Background(), secret)
 }
 
+// CreateSecretWithContext creates a new secret and returns it.
+// The provided context controls cancellation and deadlines for all HTTP requests made.
+func (s Server) CreateSecretWithContext(ctx context.Context, secret Secret) (*Secret, error) {
+	return s.writeSecret(ctx, secret, "POST", "/")
+}
+
+// UpdateSecret updates an existing secret and returns it.
+// It uses context.Background() internally; use UpdateSecretWithContext to supply a context.
 func (s Server) UpdateSecret(secret Secret) (*Secret, error) {
+	return s.UpdateSecretWithContext(context.Background(), secret)
+}
+
+// UpdateSecretWithContext updates an existing secret and returns it.
+// The provided context controls cancellation and deadlines for all HTTP requests made.
+func (s Server) UpdateSecretWithContext(ctx context.Context, secret Secret) (*Secret, error) {
 	if secret.SshKeyArgs != nil && (secret.SshKeyArgs.GenerateSshKeys || secret.SshKeyArgs.GeneratePassphrase) {
 		err := fmt.Errorf("[ERROR] SSH key and passphrase generation is only supported during secret creation. "+
 			"Could not update the secret named '%s'", secret.Name)
 		return nil, err
 	}
 	secret.SshKeyArgs = nil
-	return s.writeSecret(secret, "PUT", strconv.Itoa(secret.ID))
+	return s.writeSecret(ctx, secret, "PUT", strconv.Itoa(secret.ID))
 }
 
-func (s Server) writeSecret(secret Secret, method string, path string) (*Secret, error) {
+func (s Server) writeSecret(ctx context.Context, secret Secret, method string, path string) (*Secret, error) {
 	writtenSecret := new(Secret)
 
-	template, err := s.SecretTemplate(secret.SecretTemplateID)
+	template, err := s.SecretTemplateWithContext(ctx, secret.SecretTemplateID)
 	if err != nil {
 		return nil, err
 	}
@@ -195,7 +234,7 @@ func (s Server) writeSecret(secret Secret, method string, path string) (*Secret,
 		secret.Fields = make([]SecretField, 0)
 	}
 
-	if data, err := s.accessResource(method, resource, path, secret); err == nil {
+	if data, err := s.accessResource(ctx, method, resource, path, secret); err == nil {
 		if err = json.Unmarshal(data, writtenSecret); err != nil {
 			s.log().Printf("[ERROR] error parsing response from /%s: %q", resource, data)
 			return nil, err
@@ -204,15 +243,23 @@ func (s Server) writeSecret(secret Secret, method string, path string) (*Secret,
 		return nil, err
 	}
 
-	if err := s.updateFiles(writtenSecret.ID, fileFields); err != nil {
+	if err := s.updateFiles(ctx, writtenSecret.ID, fileFields); err != nil {
 		return nil, err
 	}
 
-	return s.Secret(writtenSecret.ID)
+	return s.SecretWithContext(ctx, writtenSecret.ID)
 }
 
+// DeleteSecret deletes the secret with id from the Secret Server of the given tenant.
+// It uses context.Background() internally; use DeleteSecretWithContext to supply a context.
 func (s Server) DeleteSecret(id int) error {
-	_, err := s.accessResource("DELETE", resource, strconv.Itoa(id), nil)
+	return s.DeleteSecretWithContext(context.Background(), id)
+}
+
+// DeleteSecretWithContext deletes the secret with id from the Secret Server of the given tenant.
+// The provided context controls cancellation and deadlines for all HTTP requests made.
+func (s Server) DeleteSecretWithContext(ctx context.Context, id int) error {
+	_, err := s.accessResource(ctx, "DELETE", resource, strconv.Itoa(id), nil)
 	return err
 }
 
@@ -239,7 +286,8 @@ func (s Secret) FieldById(fieldId int) (string, bool) {
 // updateFiles iterates the list of file fields and if the field's item value is empty,
 // deletes the file, otherwise, uploads the contents of the item value as the new/updated
 // file attachment.
-func (s Server) updateFiles(secretId int, fileFields []SecretField) error {
+// ctx controls cancellation and deadlines for all HTTP requests made within this call.
+func (s Server) updateFiles(ctx context.Context, secretId int, fileFields []SecretField) error {
 	type fieldMod struct {
 		Slug  string
 		Dirty bool
@@ -260,11 +308,11 @@ func (s Server) updateFiles(secretId int, fileFields []SecretField) error {
 		if element.ItemValue == "" {
 			path = fmt.Sprintf("%d/general", secretId)
 			input = secretPatch{Data: fieldMods{SecretFields: []fieldMod{{Slug: element.Slug, Dirty: true, Value: nil}}}}
-			if _, err := s.accessResource("PATCH", resource, path, input); err != nil {
+			if _, err := s.accessResource(ctx, "PATCH", resource, path, input); err != nil {
 				return err
 			}
 		} else {
-			if err := s.uploadFile(secretId, element); err != nil {
+			if err := s.uploadFile(ctx, secretId, element); err != nil {
 				return err
 			}
 		}

--- a/server/secret_template.go
+++ b/server/secret_template.go
@@ -1,6 +1,7 @@
 package server
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"strconv"
@@ -23,11 +24,18 @@ type SecretTemplateField struct {
 	IsFile, IsList, IsNotes, IsPassword, IsRequired, IsUrl  bool
 }
 
-// SecretTemplate gets the secret template with id from the Secret Server of the given tenant
+// SecretTemplate gets the secret template with id from the Secret Server of the given tenant.
+// It uses context.Background() internally; use SecretTemplateWithContext to supply a context.
 func (s Server) SecretTemplate(id int) (*SecretTemplate, error) {
+	return s.SecretTemplateWithContext(context.Background(), id)
+}
+
+// SecretTemplateWithContext gets the secret template with id from the Secret Server of the given tenant.
+// The provided context controls cancellation and deadlines for all HTTP requests made.
+func (s Server) SecretTemplateWithContext(ctx context.Context, id int) (*SecretTemplate, error) {
 	secretTemplate := new(SecretTemplate)
 
-	if data, err := s.accessResource("GET", templateResource, strconv.Itoa(id), nil); err == nil {
+	if data, err := s.accessResource(ctx, "GET", templateResource, strconv.Itoa(id), nil); err == nil {
 		if err = json.Unmarshal(data, secretTemplate); err != nil {
 			s.log().Printf("[ERROR] error parsing response from /%s/%d: %q", templateResource, id, data)
 			return nil, err
@@ -42,8 +50,16 @@ func (s Server) SecretTemplate(id int) (*SecretTemplate, error) {
 // GeneratePassword generates and returns a password for the secret field identified by the given slug on the given
 // template. The password adheres to the password requirements associated with the field. NOTE: this should only be
 // used with fields whose IsPassword property is true.
+// It uses context.Background() internally; use GeneratePasswordWithContext to supply a context.
 func (s Server) GeneratePassword(slug string, template *SecretTemplate) (string, error) {
+	return s.GeneratePasswordWithContext(context.Background(), slug, template)
+}
 
+// GeneratePasswordWithContext generates and returns a password for the secret field identified by the given slug on
+// the given template. The password adheres to the password requirements associated with the field. NOTE: this should
+// only be used with fields whose IsPassword property is true.
+// The provided context controls cancellation and deadlines for all HTTP requests made.
+func (s Server) GeneratePasswordWithContext(ctx context.Context, slug string, template *SecretTemplate) (string, error) {
 	fieldId, found := template.FieldSlugToId(slug)
 
 	if !found {
@@ -51,7 +67,7 @@ func (s Server) GeneratePassword(slug string, template *SecretTemplate) (string,
 	}
 	path := fmt.Sprintf("generate-password/%d", fieldId)
 
-	if data, err := s.accessResource("POST", templateResource, path, nil); err == nil {
+	if data, err := s.accessResource(ctx, "POST", templateResource, path, nil); err == nil {
 		passwordWithQuotes := string(data)
 		return passwordWithQuotes[1 : len(passwordWithQuotes)-1], nil
 	} else {

--- a/server/server.go
+++ b/server/server.go
@@ -2,6 +2,7 @@ package server
 
 import (
 	"bytes"
+	"context"
 	"crypto/tls"
 	"encoding/json"
 	"fmt"
@@ -175,7 +176,8 @@ func (s Server) urlForSearch(resource, searchText, fieldName string) string {
 
 // accessResource uses the accessToken to access the API resource.
 // It assumes an appropriate combination of method, resource, path and input.
-func (s Server) accessResource(method, resource, path string, input interface{}) ([]byte, error) {
+// ctx controls cancellation and deadlines for all HTTP requests made within this call.
+func (s Server) accessResource(ctx context.Context, method, resource, path string, input interface{}) ([]byte, error) {
 	switch resource {
 	case "secrets":
 	case "secret-templates":
@@ -197,14 +199,14 @@ func (s Server) accessResource(method, resource, path string, input interface{})
 		}
 	}
 
-	accessToken, err := s.getAccessToken()
+	accessToken, err := s.getAccessToken(ctx)
 
 	if err != nil {
 		s.log().Print("[ERROR] error getting accessToken:", err)
 		return nil, err
 	}
 
-	req, err := http.NewRequest(method, s.urlFor(resource, path), body)
+	req, err := http.NewRequestWithContext(ctx, method, s.urlFor(resource, path), body)
 
 	if err != nil {
 		s.log().Printf("[ERROR] creating req: %s /%s/%s: %s", method, resource, path, err)
@@ -233,8 +235,9 @@ func (s Server) accessResource(method, resource, path string, input interface{})
 
 // searchResources uses the accessToken to search for API resources.
 // It assumes an appropriate combination of resource, search text.
-// field is optional
-func (s Server) searchResources(resource, searchText, field string) ([]byte, error) {
+// field is optional.
+// ctx controls cancellation and deadlines for all HTTP requests made within this call.
+func (s Server) searchResources(ctx context.Context, resource, searchText, field string) ([]byte, error) {
 	switch resource {
 	case "secrets":
 	default:
@@ -247,14 +250,14 @@ func (s Server) searchResources(resource, searchText, field string) ([]byte, err
 	method := "GET"
 	body := bytes.NewBuffer([]byte{})
 
-	accessToken, err := s.getAccessToken()
+	accessToken, err := s.getAccessToken(ctx)
 
 	if err != nil {
 		s.log().Print("[ERROR] error getting accessToken:", err)
 		return nil, err
 	}
 
-	req, err := http.NewRequest(method, s.urlForSearch(resource, searchText, field), body)
+	req, err := http.NewRequestWithContext(ctx, method, s.urlForSearch(resource, searchText, field), body)
 
 	if err != nil {
 		s.log().Printf("[ERROR] creating req: %s /%s/%s/%s: %s", method, resource, searchText, field, err)
@@ -272,13 +275,14 @@ func (s Server) searchResources(resource, searchText, field string) ([]byte, err
 
 // uploadFile uploads the file described in the given fileField to the
 // secret at the given secretId as a multipart/form-data request.
-func (s Server) uploadFile(secretId int, fileField SecretField) error {
+// ctx controls cancellation and deadlines for all HTTP requests made within this call.
+func (s Server) uploadFile(ctx context.Context, secretId int, fileField SecretField) error {
 	s.log().Printf("[DEBUG] uploading a file to the '%s' field with filename '%s'", fileField.Slug, fileField.Filename)
 	body := bytes.NewBuffer([]byte{})
 	path := fmt.Sprintf("%d/fields/%s", secretId, fileField.Slug)
 
 	// Fetch the access token
-	accessToken, err := s.getAccessToken()
+	accessToken, err := s.getAccessToken(ctx)
 	if err != nil {
 		s.log().Print("[ERROR] error getting accessToken:", err)
 		return err
@@ -308,7 +312,7 @@ func (s Server) uploadFile(secretId int, fileField SecretField) error {
 	}
 
 	// Make the request
-	req, err := http.NewRequest("PUT", s.urlFor(resource, path), body)
+	req, err := http.NewRequestWithContext(ctx, "PUT", s.urlFor(resource, path), body)
 	if err != nil {
 		return err
 	}
@@ -375,7 +379,8 @@ func (s *Server) cacheKey(baseURL string) string {
 
 // getAccessToken gets an OAuth2 Access Grant and returns the token
 // endpoint and get an accessGrant.
-func (s *Server) getAccessToken() (string, error) {
+// ctx controls cancellation and deadlines for all HTTP requests made within this call.
+func (s *Server) getAccessToken(ctx context.Context) (string, error) {
 	if s.Credentials.Token != "" {
 		return s.Credentials.Token, nil
 	}
@@ -387,7 +392,7 @@ func (s *Server) getAccessToken() (string, error) {
 		baseURL = s.ServerURL
 	}
 
-	response, err := s.checkPlatformDetails(baseURL)
+	response, err := s.checkPlatformDetails(ctx, baseURL)
 	if err != nil {
 		s.log().Print("Error while checking server details:", err)
 		return "", err
@@ -408,9 +413,17 @@ func (s *Server) getAccessToken() (string, error) {
 			values["domain"] = []string{s.Credentials.Domain}
 		}
 
-		body := strings.NewReader(values.Encode())
 		requestUrl := s.urlFor("token", "")
-		data, _, err := handleResponse(http.Post(requestUrl, "application/x-www-form-urlencoded", body))
+
+		// Use NewRequestWithContext so the caller's context (deadlines, cancellation) is honoured.
+		req, err := http.NewRequestWithContext(ctx, "POST", requestUrl, strings.NewReader(values.Encode()))
+		if err != nil {
+			s.log().Print("[ERROR] creating request for token endpoint:", err)
+			return "", err
+		}
+		req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+
+		data, _, err := handleResponse((&http.Client{}).Do(req))
 
 		if err != nil {
 			s.log().Print("[ERROR] grant response error:", err)
@@ -438,92 +451,110 @@ func (s *Server) getAccessToken() (string, error) {
 	return response, nil
 }
 
-func (s *Server) checkPlatformDetails(baseURL string) (string, error) {
+func (s *Server) checkPlatformDetails(ctx context.Context, baseURL string) (string, error) {
 	platformHelthCheckUrl := fmt.Sprintf("%s/%s", strings.Trim(baseURL, "/"), "health")
 	ssHealthCheckUrl := fmt.Sprintf("%s/%s", strings.Trim(baseURL, "/"), "api/v1/healthcheck")
 
-	isHealthy := checkJSONResponse(ssHealthCheckUrl, s.log())
+	isHealthy := checkJSONResponse(ctx, ssHealthCheckUrl, s.log())
 	if isHealthy {
 		return "", nil
-	} else {
-		isHealthy := checkJSONResponse(platformHelthCheckUrl, s.log())
-		if isHealthy {
+	}
+	// If the context was cancelled or timed out while probing the health endpoint,
+	// propagate that error instead of falling through to "invalid URL".
+	if ctxErr := ctx.Err(); ctxErr != nil {
+		return "", ctxErr
+	}
 
-			accessToken, found := s.getCacheAccessToken(baseURL)
-			if !found {
-				requestData := url.Values{}
-				requestData.Set("grant_type", "client_credentials")
-				requestData.Set("client_id", s.Credentials.Username)
-				requestData.Set("client_secret", s.Credentials.Password)
-				requestData.Set("scope", "xpmheadless")
+	isHealthy = checkJSONResponse(ctx, platformHelthCheckUrl, s.log())
+	if isHealthy {
 
-				req, err := http.NewRequest("POST", fmt.Sprintf("%s/%s", strings.Trim(baseURL, "/"), "identity/api/oauth2/token/xpmplatform"), bytes.NewBufferString(requestData.Encode()))
-				if err != nil {
-					s.log().Print("Error creating HTTP request:", err)
-					return "", err
-				}
+		accessToken, found := s.getCacheAccessToken(baseURL)
+		if !found {
+			requestData := url.Values{}
+			requestData.Set("grant_type", "client_credentials")
+			requestData.Set("client_id", s.Credentials.Username)
+			requestData.Set("client_secret", s.Credentials.Password)
+			requestData.Set("scope", "xpmheadless")
 
-				req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
-
-				data, _, err := handleResponse((&http.Client{}).Do(req))
-				if err != nil {
-					s.log().Print("[ERROR] get token response error:", err)
-					return "", err
-				}
-
-				var tokenjsonResponse OAuthTokens
-				if err = json.Unmarshal(data, &tokenjsonResponse); err != nil {
-					s.log().Print("[ERROR] parsing get token response:", err)
-					return "", err
-				}
-				accessToken = tokenjsonResponse.AccessToken
-
-				if err = s.setCacheAccessToken(tokenjsonResponse.AccessToken, tokenjsonResponse.ExpiresIn, baseURL); err != nil {
-					s.log().Print("[ERROR] caching access token:", err)
-					return "", err
-				}
-			}
-
-			req, err := http.NewRequest("GET", fmt.Sprintf("%s/%s", strings.Trim(baseURL, "/"), "vaultbroker/api/vaults"), bytes.NewBuffer([]byte{}))
+			req, err := http.NewRequestWithContext(ctx, "POST", fmt.Sprintf("%s/%s", strings.Trim(baseURL, "/"), "identity/api/oauth2/token/xpmplatform"), bytes.NewBufferString(requestData.Encode()))
 			if err != nil {
 				s.log().Print("Error creating HTTP request:", err)
 				return "", err
 			}
-			req.Header.Add("Authorization", "Bearer "+accessToken)
+
+			req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
 
 			data, _, err := handleResponse((&http.Client{}).Do(req))
 			if err != nil {
-				s.log().Print("[ERROR] get vaults response error:", err)
+				s.log().Print("[ERROR] get token response error:", err)
 				return "", err
 			}
 
-			var vaultJsonResponse VaultsResponseModel
-			if err = json.Unmarshal(data, &vaultJsonResponse); err != nil {
-				s.log().Print("[ERROR] parsing vaults response:", err)
+			var tokenjsonResponse OAuthTokens
+			if err = json.Unmarshal(data, &tokenjsonResponse); err != nil {
+				s.log().Print("[ERROR] parsing get token response:", err)
 				return "", err
 			}
+			accessToken = tokenjsonResponse.AccessToken
 
-			var vaultURL string
-			for _, vault := range vaultJsonResponse.Vaults {
-				if vault.IsDefault && vault.IsActive {
-					vaultURL = vault.Connection.Url
-					break
-				}
+			if err = s.setCacheAccessToken(tokenjsonResponse.AccessToken, tokenjsonResponse.ExpiresIn, baseURL); err != nil {
+				s.log().Print("[ERROR] caching access token:", err)
+				return "", err
 			}
-			if vaultURL != "" {
-				s.ServerURL = vaultURL
-			} else {
-				return "", fmt.Errorf("no configured vault found")
-			}
-
-			return accessToken, nil
 		}
+
+		req, err := http.NewRequestWithContext(ctx, "GET", fmt.Sprintf("%s/%s", strings.Trim(baseURL, "/"), "vaultbroker/api/vaults"), bytes.NewBuffer([]byte{}))
+		if err != nil {
+			s.log().Print("Error creating HTTP request:", err)
+			return "", err
+		}
+		req.Header.Add("Authorization", "Bearer "+accessToken)
+
+		data, _, err := handleResponse((&http.Client{}).Do(req))
+		if err != nil {
+			s.log().Print("[ERROR] get vaults response error:", err)
+			return "", err
+		}
+
+		var vaultJsonResponse VaultsResponseModel
+		if err = json.Unmarshal(data, &vaultJsonResponse); err != nil {
+			s.log().Print("[ERROR] parsing vaults response:", err)
+			return "", err
+		}
+
+		var vaultURL string
+		for _, vault := range vaultJsonResponse.Vaults {
+			if vault.IsDefault && vault.IsActive {
+				vaultURL = vault.Connection.Url
+				break
+			}
+		}
+		if vaultURL != "" {
+			s.ServerURL = vaultURL
+		} else {
+			return "", fmt.Errorf("no configured vault found")
+		}
+
+		return accessToken, nil
+	}
+	// Propagate context errors rather than masking them as "invalid URL".
+	if ctxErr := ctx.Err(); ctxErr != nil {
+		return "", ctxErr
 	}
 	return "", fmt.Errorf("invalid URL")
 }
 
-func checkJSONResponse(url string, logger Logger) bool {
-	response, err := http.Get(url)
+// checkJSONResponse makes a GET request to url and returns true when the
+// response body indicates a healthy JSON service.
+// ctx controls cancellation and deadlines for the underlying HTTP request.
+func checkJSONResponse(ctx context.Context, url string, logger Logger) bool {
+	req, err := http.NewRequestWithContext(ctx, "GET", url, nil)
+	if err != nil {
+		logger.Println("Error creating GET request:", err)
+		return false
+	}
+
+	response, err := (&http.Client{}).Do(req)
 	if err != nil {
 		logger.Println("Error making GET request:", err)
 		return false


### PR DESCRIPTION
## Pull request checklist

Please check if your PR fulfills the following requirements:

- [x] You have read the contributing guide
- [x] Tests for the changes have been added
- [x] The documentation has been reviewed and updated as needed

## What is the current behavior?

All public API methods (`Secret`, `Secrets`, `SecretByPath`, `CreateSecret`, `UpdateSecret`, `DeleteSecret`, `SecretTemplate`, `GeneratePassword`) make HTTP requests without any caller-supplied context. There is no way to attach deadlines, cancellation signals, or tracing to the underlying requests.

Issue Number: N/A

## What is the new behavior?

- Every public method now has a `WithContext` counterpart (e.g. `SecretWithContext`, `SecretsWithContext`, etc.) that accepts a `context.Context` as its first argument.
- The original methods are preserved unchanged and delegate to their `WithContext` counterpart using `context.Background()`, so there are **no breaking changes**.
- Context is propagated all the way through the internal call chain down to each individual HTTP request via `http.NewRequestWithContext`.
- `http.Post` and `http.Get` (which do not accept a context) are replaced with `http.NewRequestWithContext` + `client.Do`.
- `checkPlatformDetails` now propagates `context.Canceled` / `context.DeadlineExceeded` instead of masking them as `"invalid URL"`.

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

## Other relevant information

Follows the standard Go idiom used by `database/sql` (`Query` / `QueryContext`): existing callers continue to work without modification, while new callers can opt into context-aware behaviour.